### PR TITLE
Adding planar renderer trait

### DIFF
--- a/examples/custom_material.rs
+++ b/examples/custom_material.rs
@@ -132,6 +132,6 @@ static NORMAL_FRAGMENT_SRC: &'static str = "#version 100
 varying vec3 ls_normal;
 
 void main() {
-    gl_FragColor = vec4((ls_normal + 1.0) / 2.0, 1.0);
+    gl_FragColor = vec4((ls_normal + 1.0) / 2.0, 0.5);
 }
 ";

--- a/src/builtin/normals_material.rs
+++ b/src/builtin/normals_material.rs
@@ -1,10 +1,10 @@
 use crate::camera::Camera;
 use crate::context::Context;
 use crate::light::Light;
-use na::{Isometry3, Matrix3, Matrix4, Point3, Vector3};
 use crate::resource::Material;
 use crate::resource::{Effect, Mesh, ShaderAttribute, ShaderUniform};
 use crate::scene::ObjectData;
+use na::{Isometry3, Matrix3, Matrix4, Point3, Vector3};
 
 #[path = "../error.rs"]
 mod error;

--- a/src/builtin/object_material.rs
+++ b/src/builtin/object_material.rs
@@ -1,10 +1,10 @@
 use crate::camera::Camera;
 use crate::context::Context;
 use crate::light::Light;
-use na::{Isometry3, Matrix3, Matrix4, Point2, Point3, Vector3};
 use crate::resource::Material;
 use crate::resource::{Effect, Mesh, ShaderAttribute, ShaderUniform};
 use crate::scene::ObjectData;
+use na::{Isometry3, Matrix3, Matrix4, Point2, Point3, Vector3};
 
 #[path = "../error.rs"]
 mod error;

--- a/src/builtin/planar_object_material.rs
+++ b/src/builtin/planar_object_material.rs
@@ -1,9 +1,9 @@
 use crate::context::Context;
-use na::{Isometry2, Matrix2, Matrix3, Point2, Point3, Vector2};
 use crate::planar_camera::PlanarCamera;
 use crate::resource::PlanarMaterial;
 use crate::resource::{Effect, PlanarMesh, ShaderAttribute, ShaderUniform};
 use crate::scene::PlanarObjectData;
+use na::{Isometry2, Matrix2, Matrix3, Point2, Point3, Vector2};
 
 #[path = "../error.rs"]
 mod error;

--- a/src/builtin/uvs_material.rs
+++ b/src/builtin/uvs_material.rs
@@ -1,10 +1,10 @@
 use crate::camera::Camera;
 use crate::context::Context;
 use crate::light::Light;
-use na::{Isometry3, Matrix3, Matrix4, Point2, Point3, Vector3};
 use crate::resource::Material;
 use crate::resource::{Effect, Mesh, ShaderAttribute, ShaderUniform};
 use crate::scene::ObjectData;
+use na::{Isometry3, Matrix3, Matrix4, Point2, Point3, Vector3};
 
 #[path = "../error.rs"]
 mod error;

--- a/src/camera/arc_ball.rs
+++ b/src/camera/arc_ball.rs
@@ -1,9 +1,9 @@
 use crate::camera::Camera;
 use crate::event::{Action, Key, Modifiers, MouseButton, WindowEvent};
-use na::{self, Isometry3, Matrix4, Perspective3, Point3, Unit, UnitQuaternion, Vector2, Vector3};
 use crate::resource::ShaderUniform;
-use std::f32;
 use crate::window::Canvas;
+use na::{self, Isometry3, Matrix4, Perspective3, Point3, Unit, UnitQuaternion, Vector2, Vector3};
+use std::f32;
 
 /// Arc-ball camera mode.
 ///
@@ -135,6 +135,10 @@ impl ArcBall {
 
         self.update_restrictions();
         self.update_projviews();
+    }
+
+    pub fn set_dist_step(&mut self, step: f32) {
+        self.dist_step = step;
     }
 
     /// The minimum pitch of the camera.

--- a/src/camera/camera.rs
+++ b/src/camera/camera.rs
@@ -1,7 +1,7 @@
 use crate::event::WindowEvent;
-use na::{Isometry3, Matrix4, Point2, Point3, Point4, Vector2, Vector3};
 use crate::resource::ShaderUniform;
 use crate::window::Canvas;
+use na::{Isometry3, Matrix4, Point2, Point3, Point4, Vector2, Vector3};
 
 /// Trait every camera must implement.
 pub trait Camera {

--- a/src/camera/first_person.rs
+++ b/src/camera/first_person.rs
@@ -1,13 +1,13 @@
 use crate::camera::Camera;
 use crate::event::{Action, Key, MouseButton, WindowEvent};
+use crate::resource::ShaderUniform;
+use crate::window::Canvas;
 use na::{
     self, Isometry3, Matrix4, Perspective3, Point3, Translation3, Unit, UnitQuaternion, Vector2,
     Vector3,
 };
 use num::Zero;
-use crate::resource::ShaderUniform;
 use std::f32;
-use crate::window::Canvas;
 
 /// First-person camera mode.
 ///

--- a/src/camera/fixed_view.rs
+++ b/src/camera/fixed_view.rs
@@ -1,9 +1,9 @@
 use crate::camera::Camera;
 use crate::event::WindowEvent;
-use na::{self, Isometry3, Matrix4, Perspective3, Point3};
 use crate::resource::ShaderUniform;
-use std::f32;
 use crate::window::Canvas;
+use na::{self, Isometry3, Matrix4, Perspective3, Point3};
+use std::f32;
 
 /// A camera that cannot move.
 #[derive(Clone, Debug)]

--- a/src/context/context.rs
+++ b/src/context/context.rs
@@ -524,6 +524,14 @@ impl Context {
         self.ctxt
             .blend_func_separate(src_rgb, dst_rgb, src_alpha, dst_alpha)
     }
+
+    pub fn blend_func(
+        &self,
+        sfactor: GLenum,
+        dfactor: GLenum,
+    ) {
+        self.ctxt.blend_func(sfactor, dfactor)
+    }
 }
 
 pub(crate) trait AbstractContextConst {
@@ -765,5 +773,11 @@ pub(crate) trait AbstractContext {
         dst_rgb: GLenum,
         src_alpha: GLenum,
         dst_alpha: GLenum,
+    );
+
+    fn blend_func(
+        &self,
+        sfactor: GLenum,
+        dfactor: GLenum,
     );
 }

--- a/src/context/context.rs
+++ b/src/context/context.rs
@@ -16,8 +16,8 @@ use gl::{
     types::GLenum as GLenumTy, types::GLintptr as GLintptrTy, types::GLsizeiptr as GLsizeiptrTy,
 };
 
-use na::{Matrix2, Matrix3, Matrix4};
 use crate::resource::GLPrimitive;
+use na::{Matrix2, Matrix3, Matrix4};
 
 #[path = "../error.rs"]
 mod error;

--- a/src/context/gl_context.rs
+++ b/src/context/gl_context.rs
@@ -7,8 +7,8 @@ use crate::context::{AbstractContext, AbstractContextConst, GLenum, GLintptr, GL
 use gl;
 use num::Zero;
 
-use crate::resource::GLPrimitive;
 use na::{Matrix2, Matrix3, Matrix4};
+use crate::resource::GLPrimitive;
 
 #[path = "../error.rs"]
 mod error;
@@ -645,5 +645,13 @@ impl AbstractContext for GLContext {
         dst_alpha: GLenum,
     ) {
         unsafe { gl::BlendFuncSeparate(src_rgb, dst_rgb, src_alpha, dst_alpha) }
+    }
+
+    fn blend_func(
+        &self,
+        sfactor: GLenum,
+        dfactor: GLenum,
+    ) {
+        unsafe { gl::BlendFunc(sfactor, dfactor) }
     }
 }

--- a/src/context/gl_context.rs
+++ b/src/context/gl_context.rs
@@ -7,8 +7,8 @@ use crate::context::{AbstractContext, AbstractContextConst, GLenum, GLintptr, GL
 use gl;
 use num::Zero;
 
-use na::{Matrix2, Matrix3, Matrix4};
 use crate::resource::GLPrimitive;
+use na::{Matrix2, Matrix3, Matrix4};
 
 #[path = "../error.rs"]
 mod error;

--- a/src/context/webgl_context.rs
+++ b/src/context/webgl_context.rs
@@ -10,8 +10,8 @@ use crate::context::{AbstractContext, AbstractContextConst, GLenum, GLintptr, GL
 use stdweb::web::{self, html_element::CanvasElement, IParentNode, TypedArray};
 use stdweb::{self, unstable::TryInto, Value};
 
-use na::{Matrix2, Matrix3, Matrix4};
 use crate::resource::{GLPrimitive, PrimitiveArray};
+use na::{Matrix2, Matrix3, Matrix4};
 
 /// A WebGL 1.0 cotnext.
 #[derive(Clone)]

--- a/src/context/webgl_context.rs
+++ b/src/context/webgl_context.rs
@@ -614,4 +614,12 @@ impl AbstractContext for WebGLContext {
         self.ctxt
             .blend_func_separate(src_rgb, dst_rgb, src_alpha, dst_alpha)
     }
+
+    pub fn blend_func(
+        &self,
+        sfactor: GLenum,
+        dfactor: GLenum,
+    ) {
+        self.ctxt.blend_func(sfactor, dfactor)
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,9 +122,9 @@ Thanks to all the Rustaceans for their help, and their OpenGL bindings.
 
 #![deny(non_camel_case_types)]
 #![deny(unused_parens)]
-#![warn(non_upper_case_globals)] // FIXME: should be denied.
+#![allow(non_upper_case_globals)] // FIXME: should be denied.
 #![deny(unused_qualifications)]
-#![warn(missing_docs)] // FIXME: should be denied.
+#![allow(missing_docs)] // FIXME: should be denied.
 #![warn(unused_results)]
 #![allow(unused_unsafe)] // FIXME: should be denied
 #![allow(missing_copy_implementations)]

--- a/src/loader/obj.rs
+++ b/src/loader/obj.rs
@@ -2,10 +2,10 @@
 
 use crate::loader::mtl;
 use crate::loader::mtl::MtlMaterial;
-use na::{Point2, Point3, Vector3};
-use num::Bounded;
 use crate::resource::GPUVec;
 use crate::resource::{AllocationType, BufferType, Mesh};
+use na::{Point2, Point3, Vector3};
+use num::Bounded;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::fs::File;

--- a/src/planar_camera/fixed_view.rs
+++ b/src/planar_camera/fixed_view.rs
@@ -1,9 +1,9 @@
 use crate::event::WindowEvent;
-use na::{self, Matrix3, Point2, Vector2, Vector3};
 use crate::planar_camera::PlanarCamera;
 use crate::resource::ShaderUniform;
-use std::f32;
 use crate::window::Canvas;
+use na::{self, Matrix3, Point2, Vector2, Vector3};
+use std::f32;
 
 /// A camera that cannot move.
 #[derive(Clone, Debug)]

--- a/src/planar_camera/planar_camera.rs
+++ b/src/planar_camera/planar_camera.rs
@@ -1,7 +1,7 @@
 use crate::event::WindowEvent;
-use na::{Matrix3, Point2, Vector2};
 use crate::resource::ShaderUniform;
 use crate::window::Canvas;
+use na::{Matrix3, Point2, Vector2};
 
 /// Trait every 2D camera must implement.
 pub trait PlanarCamera {

--- a/src/planar_camera/sidescroll.rs
+++ b/src/planar_camera/sidescroll.rs
@@ -1,10 +1,10 @@
 use crate::event::{Action, MouseButton, WindowEvent};
-use na::{self, Matrix3, Point2, Translation2, Vector2};
-use num::Pow;
 use crate::planar_camera::PlanarCamera;
 use crate::resource::ShaderUniform;
-use std::f32;
 use crate::window::Canvas;
+use na::{self, Matrix3, Point2, Translation2, Vector2};
+use num::Pow;
+use std::f32;
 
 /// A 2D camera that can be zoomed and panned.
 #[derive(Clone, Debug)]
@@ -66,6 +66,11 @@ impl Sidescroll {
 
         self.update_restrictions();
         self.update_projviews();
+    }
+
+    /// Sets the zoom step of the camera
+    pub fn set_zoom_step(&mut self, zoom_step: f32) {
+        self.zoom_step = zoom_step;
     }
 
     /// Move the camera such that it is centered on a specific point.

--- a/src/planar_line_renderer.rs
+++ b/src/planar_line_renderer.rs
@@ -1,10 +1,10 @@
 //! A batched line renderer.
 
 use crate::context::Context;
-use na::{Matrix3, Point2, Point3};
 use crate::planar_camera::PlanarCamera;
-use crate::resource::{AllocationType, BufferType, Effect, GPUVec, ShaderAttribute, ShaderUniform};
 use crate::renderer::PlanarRenderer;
+use crate::resource::{AllocationType, BufferType, Effect, GPUVec, ShaderAttribute, ShaderUniform};
+use na::{Matrix3, Point2, Point3};
 
 #[path = "error.rs"]
 mod error;

--- a/src/planar_line_renderer.rs
+++ b/src/planar_line_renderer.rs
@@ -4,6 +4,7 @@ use crate::context::Context;
 use na::{Matrix3, Point2, Point3};
 use crate::planar_camera::PlanarCamera;
 use crate::resource::{AllocationType, BufferType, Effect, GPUVec, ShaderAttribute, ShaderUniform};
+use crate::renderer::PlanarRenderer;
 
 #[path = "error.rs"]
 mod error;
@@ -62,10 +63,12 @@ impl PlanarLineRenderer {
             colors.push(color);
         }
     }
+}
 
+impl PlanarRenderer for PlanarLineRenderer {
     /// Actually draws the lines.
-    pub fn render(&mut self, camera: &mut dyn PlanarCamera) {
-        if self.lines.len() == 0 {
+    fn render(&mut self, planar_camera: &mut dyn PlanarCamera) {
+        if !self.needs_rendering() {
             return;
         }
 
@@ -73,7 +76,7 @@ impl PlanarLineRenderer {
         self.pos.enable();
         self.color.enable();
 
-        camera.upload(&mut self.proj, &mut self.view);
+        planar_camera.upload(&mut self.proj, &mut self.view);
 
         self.color.bind_sub_buffer(&mut self.colors, 0, 0);
         self.pos.bind_sub_buffer(&mut self.lines, 0, 0);

--- a/src/renderer/conrod_renderer.rs
+++ b/src/renderer/conrod_renderer.rs
@@ -1,14 +1,14 @@
 //! A renderer for Conrod primitives.
 
+use crate::context::{Context, Texture};
+use crate::resource::{AllocationType, BufferType, Effect, GPUVec, ShaderAttribute, ShaderUniform};
+use crate::text::Font;
 use conrod::position::Rect;
 use conrod::text::GlyphCache;
 use conrod::{render::PrimitiveKind, Ui};
-use crate::context::{Context, Texture};
 use na::{Point2, Point3, Point4, Vector2};
-use crate::resource::{AllocationType, BufferType, Effect, GPUVec, ShaderAttribute, ShaderUniform};
 use rusttype::gpu_cache::Cache;
 use std::rc::Rc;
-use crate::text::Font;
 
 #[path = "../error.rs"]
 mod error;

--- a/src/renderer/conrod_renderer.rs
+++ b/src/renderer/conrod_renderer.rs
@@ -7,7 +7,6 @@ use crate::context::{Context, Texture};
 use na::{Point2, Point3, Point4, Vector2};
 use crate::resource::{AllocationType, BufferType, Effect, GPUVec, ShaderAttribute, ShaderUniform};
 use rusttype::gpu_cache::Cache;
-use std::collections::HashMap;
 use std::rc::Rc;
 use crate::text::Font;
 

--- a/src/renderer/line_renderer.rs
+++ b/src/renderer/line_renderer.rs
@@ -2,9 +2,9 @@
 
 use crate::camera::Camera;
 use crate::context::Context;
-use na::{Matrix4, Point3};
 use crate::renderer::Renderer;
 use crate::resource::{AllocationType, BufferType, Effect, GPUVec, ShaderAttribute, ShaderUniform};
+use na::{Matrix4, Point3};
 
 #[path = "../error.rs"]
 mod error;

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -4,7 +4,7 @@
 pub use self::conrod_renderer::ConrodRenderer;
 pub use self::line_renderer::LineRenderer;
 pub use self::point_renderer::PointRenderer;
-pub use self::renderer::Renderer;
+pub use self::renderer::{Renderer, PlanarRenderer};
 
 #[cfg(feature = "conrod")]
 mod conrod_renderer;

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -4,7 +4,7 @@
 pub use self::conrod_renderer::ConrodRenderer;
 pub use self::line_renderer::LineRenderer;
 pub use self::point_renderer::PointRenderer;
-pub use self::renderer::{Renderer, PlanarRenderer};
+pub use self::renderer::{PlanarRenderer, Renderer};
 
 #[cfg(feature = "conrod")]
 mod conrod_renderer;

--- a/src/renderer/point_renderer.rs
+++ b/src/renderer/point_renderer.rs
@@ -2,9 +2,9 @@
 
 use crate::camera::Camera;
 use crate::context::Context;
-use na::{Matrix4, Point3};
 use crate::renderer::Renderer;
 use crate::resource::{AllocationType, BufferType, Effect, GPUVec, ShaderAttribute, ShaderUniform};
+use na::{Matrix4, Point3};
 
 #[path = "../error.rs"]
 mod error;
@@ -85,7 +85,7 @@ impl PersistentPointRenderer {
             view: shader.get_uniform::<Matrix4<f32>>("view").unwrap(),
             shader,
             point_size: 1.0,
-            visible: true
+            visible: true,
         }
     }
 
@@ -107,12 +107,12 @@ impl PersistentPointRenderer {
     }
 
     /// Prevent this renderer from showing any points
-    pub fn hide(&mut self){
+    pub fn hide(&mut self) {
         self.visible = false
     }
 
     /// Enable rendering for the renderer, only needed if you dissabled it using hide
-    pub fn show(&mut self){
+    pub fn show(&mut self) {
         self.visible = true
     }
 
@@ -178,9 +178,7 @@ impl Renderer for PersistentPointRenderer {
         self.pos.disable();
         self.color.disable();
     }
-
 }
-
 
 /// Vertex shader used by the material to display point.
 pub static POINTS_VERTEX_SRC: &'static str = A_VERY_LONG_STRING;

--- a/src/renderer/renderer.rs
+++ b/src/renderer/renderer.rs
@@ -1,7 +1,14 @@
 use crate::camera::Camera;
+use crate::planar_camera::PlanarCamera;
 
 /// Trait implemented by custom renderer.
 pub trait Renderer {
     /// Perform a rendering pass.
     fn render(&mut self, pass: usize, camera: &mut dyn Camera);
+}
+
+/// Trait implemented by customer planer renderers.
+pub trait PlanarRenderer {
+    /// Perform a rendering pass.
+    fn render(&mut self, camera: &mut dyn PlanarCamera);
 }

--- a/src/resource/material.rs
+++ b/src/resource/material.rs
@@ -2,10 +2,10 @@
 
 use crate::camera::Camera;
 use crate::light::Light;
-use na::{Isometry2, Isometry3, Vector2, Vector3};
 use crate::planar_camera::PlanarCamera;
 use crate::resource::{Mesh, PlanarMesh};
 use crate::scene::{ObjectData, PlanarObjectData};
+use na::{Isometry2, Isometry3, Vector2, Vector3};
 
 /// Trait implemented by materials.
 pub trait Material {

--- a/src/resource/mesh.rs
+++ b/src/resource/mesh.rs
@@ -2,11 +2,11 @@
 use std::iter;
 use std::sync::{Arc, RwLock};
 
+use crate::resource::gpu_vector::{AllocationType, BufferType, GPUVec};
+use crate::resource::ShaderAttribute;
 use na::{self, Point2, Point3, Vector3};
 use ncollide3d::procedural::{IndexBuffer, TriMesh};
 use num::Zero;
-use crate::resource::gpu_vector::{AllocationType, BufferType, GPUVec};
-use crate::resource::ShaderAttribute;
 
 #[path = "../error.rs"]
 mod error;

--- a/src/resource/mesh_manager.rs
+++ b/src/resource/mesh_manager.rs
@@ -2,9 +2,9 @@
 
 use crate::loader::mtl::MtlMaterial;
 use crate::loader::obj;
+use crate::resource::Mesh;
 use ncollide3d::procedural;
 use ncollide3d::procedural::TriMesh;
-use crate::resource::Mesh;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::io::Result as IoResult;

--- a/src/resource/mod.rs
+++ b/src/resource/mod.rs
@@ -2,7 +2,9 @@
 
 pub use crate::context::Texture;
 pub use crate::resource::effect::{Effect, ShaderAttribute, ShaderUniform};
-pub use crate::resource::framebuffer_manager::{FramebufferManager, OffscreenBuffers, RenderTarget};
+pub use crate::resource::framebuffer_manager::{
+    FramebufferManager, OffscreenBuffers, RenderTarget,
+};
 pub use crate::resource::gl_primitive::{GLPrimitive, PrimitiveArray};
 pub use crate::resource::gpu_vector::{AllocationType, BufferType, GPUVec};
 pub use crate::resource::material::{Material, PlanarMaterial};

--- a/src/resource/planar_mesh.rs
+++ b/src/resource/planar_mesh.rs
@@ -2,9 +2,9 @@
 use std::iter;
 use std::sync::{Arc, RwLock};
 
-use na::{Point2, Point3};
 use crate::resource::gpu_vector::{AllocationType, BufferType, GPUVec};
 use crate::resource::ShaderAttribute;
+use na::{Point2, Point3};
 
 #[path = "../error.rs"]
 mod error;

--- a/src/scene/object.rs
+++ b/src/scene/object.rs
@@ -2,8 +2,8 @@
 
 use crate::camera::Camera;
 use crate::light::Light;
-use na::{Isometry3, Point2, Point3, Vector3};
 use crate::resource::{Material, Mesh, Texture, TextureManager};
+use na::{Isometry3, Point2, Point3, Vector3};
 use std::any::Any;
 use std::cell::RefCell;
 use std::path::Path;

--- a/src/scene/planar_object.rs
+++ b/src/scene/planar_object.rs
@@ -1,8 +1,8 @@
 //! Data structure of a scene node.
 
-use na::{Isometry2, Point2, Point3, Vector2};
 use crate::planar_camera::PlanarCamera;
 use crate::resource::{PlanarMaterial, PlanarMesh, Texture, TextureManager};
+use na::{Isometry2, Point2, Point3, Vector2};
 use std::any::Any;
 use std::cell::RefCell;
 use std::path::Path;

--- a/src/scene/scene_node.rs
+++ b/src/scene/scene_node.rs
@@ -1,11 +1,11 @@
 use crate::camera::Camera;
 use crate::light::Light;
+use crate::resource::{Material, MaterialManager, Mesh, MeshManager, Texture, TextureManager};
+use crate::scene::Object;
 use na;
 use na::{Isometry3, Point2, Point3, Translation3, UnitQuaternion, Vector3};
 use ncollide3d::procedural;
 use ncollide3d::procedural::TriMesh;
-use crate::resource::{Material, MaterialManager, Mesh, MeshManager, Texture, TextureManager};
-use crate::scene::Object;
 use std::cell::{Ref, RefCell, RefMut};
 use std::mem;
 use std::path::{Path, PathBuf};

--- a/src/window/canvas.rs
+++ b/src/window/canvas.rs
@@ -1,11 +1,11 @@
 use std::sync::mpsc::Sender;
 
 use crate::event::{Action, Key, MouseButton, WindowEvent};
-use image::{GenericImage, Pixel};
 #[cfg(not(any(target_arch = "wasm32", target_arch = "asmjs")))]
 use crate::window::GLCanvas as CanvasImpl;
 #[cfg(any(target_arch = "wasm32", target_arch = "asmjs"))]
 use crate::window::WebGLCanvas as CanvasImpl;
+use image::{GenericImage, Pixel};
 
 /// The possible number of samples for multisample anti-aliasing.
 #[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/window/gl_canvas.rs
+++ b/src/window/gl_canvas.rs
@@ -1,14 +1,14 @@
 use std::sync::mpsc::Sender;
 
 use crate::event::{Action, Key, Modifiers, MouseButton, TouchAction, WindowEvent};
+use crate::window::canvas::{CanvasSetup, NumSamples};
+use crate::window::AbstractCanvas;
 use gl;
 use glutin::{
     self, dpi::LogicalSize, ContextBuilder, EventsLoop, GlContext, GlRequest, GlWindow, TouchPhase,
     WindowBuilder,
 };
 use image::{GenericImage, Pixel};
-use crate::window::canvas::{CanvasSetup, NumSamples};
-use crate::window::AbstractCanvas;
 
 /// A canvas based on glutin and OpenGL.
 pub struct GLCanvas {

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -4,10 +4,11 @@ pub(crate) use self::canvas::AbstractCanvas;
 pub use self::canvas::{Canvas, CanvasSetup, NumSamples};
 #[cfg(not(any(target_arch = "wasm32", target_arch = "asmjs")))]
 pub use self::gl_canvas::GLCanvas;
-pub use self::state::State;
+pub use self::state::{State, ExtendedState};
 #[cfg(any(target_arch = "wasm32", target_arch = "asmjs"))]
 pub use self::webgl_canvas::WebGLCanvas;
 pub use self::window::Window;
+pub use self::windows_custom::CustomWindow;
 
 mod canvas;
 #[cfg(not(any(target_arch = "wasm32", target_arch = "asmjs")))]
@@ -16,3 +17,4 @@ mod state;
 #[cfg(any(target_arch = "wasm32", target_arch = "asmjs"))]
 mod webgl_canvas;
 mod window;
+mod windows_custom;

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -9,6 +9,7 @@ pub use self::state::{ExtendedState, State};
 pub use self::webgl_canvas::WebGLCanvas;
 pub use self::window::Window;
 pub use self::windows_custom::CustomWindow;
+pub use self::windows_custom::RenderMode;
 
 mod canvas;
 #[cfg(not(any(target_arch = "wasm32", target_arch = "asmjs")))]

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -4,7 +4,7 @@ pub(crate) use self::canvas::AbstractCanvas;
 pub use self::canvas::{Canvas, CanvasSetup, NumSamples};
 #[cfg(not(any(target_arch = "wasm32", target_arch = "asmjs")))]
 pub use self::gl_canvas::GLCanvas;
-pub use self::state::{State, ExtendedState};
+pub use self::state::{ExtendedState, State};
 #[cfg(any(target_arch = "wasm32", target_arch = "asmjs"))]
 pub use self::webgl_canvas::WebGLCanvas;
 pub use self::window::Window;

--- a/src/window/state.rs
+++ b/src/window/state.rs
@@ -1,8 +1,8 @@
 use crate::camera::Camera;
 use crate::planar_camera::PlanarCamera;
 use crate::post_processing::PostProcessingEffect;
-use crate::renderer::{Renderer, PlanarRenderer};
-use crate::window::{Window, CustomWindow};
+use crate::renderer::{PlanarRenderer, Renderer};
+use crate::window::{CustomWindow, Window};
 
 /// Trait implemented by objects describing state of an application.
 ///
@@ -51,14 +51,13 @@ impl State for () {
 ///
 /// Requires custom rendering implementations for both 3D and 2D.
 pub trait ExtendedState: 'static {
-
     /// Method called at each render loop before a rendering.
     fn step(&mut self, window: &mut CustomWindow);
 
     /// Method called at each render loop to retrieve the cameras, custom renderer, and post-processing effect
     /// to be used for the next render.
     fn cameras_and_effect_and_renderers(
-        &mut self
+        &mut self,
     ) -> (
         Option<&mut dyn Camera>,
         Option<&mut dyn PlanarCamera>,

--- a/src/window/state.rs
+++ b/src/window/state.rs
@@ -1,8 +1,8 @@
 use crate::camera::Camera;
 use crate::planar_camera::PlanarCamera;
 use crate::post_processing::PostProcessingEffect;
-use crate::renderer::Renderer;
-use crate::window::Window;
+use crate::renderer::{Renderer, PlanarRenderer};
+use crate::window::{Window, CustomWindow};
 
 /// Trait implemented by objects describing state of an application.
 ///
@@ -45,4 +45,31 @@ pub trait State: 'static {
 
 impl State for () {
     fn step(&mut self, _: &mut Window) {}
+}
+
+/// Trait  implemented by objects describing state of an application.
+///
+/// Requires custom rendering implementations for both 3D and 2D.
+pub trait ExtendedState: 'static {
+
+    /// Method called at each render loop before a rendering.
+    fn step(&mut self, window: &mut CustomWindow);
+
+    /// Method called at each render loop to retrieve the cameras, custom renderer, and post-processing effect
+    /// to be used for the next render.
+    fn cameras_and_effect_and_renderers(
+        &mut self
+    ) -> (
+        Option<&mut dyn Camera>,
+        Option<&mut dyn PlanarCamera>,
+        Option<&mut dyn Renderer>,
+        Option<&mut dyn PlanarRenderer>,
+        Option<&mut dyn PostProcessingEffect>,
+    ) {
+        (None, None, None, None, None)
+    }
+}
+
+impl ExtendedState for () {
+    fn step(&mut self, _: &mut CustomWindow) {}
 }

--- a/src/window/webgl_canvas.rs
+++ b/src/window/webgl_canvas.rs
@@ -6,6 +6,7 @@ use std::rc::Rc;
 use std::sync::mpsc::Sender;
 
 use crate::event::{Action, Key, Modifiers, MouseButton, TouchAction, WindowEvent};
+use crate::window::{AbstractCanvas, CanvasSetup};
 use image::{GenericImage, Pixel};
 use stdweb::web::event as webevent;
 use stdweb::web::event::{
@@ -16,7 +17,6 @@ use stdweb::web::{
     IParentNode,
 };
 use stdweb::{unstable::TryInto, Reference};
-use crate::window::{AbstractCanvas, CanvasSetup};
 
 #[derive(Clone, Debug, PartialEq, Eq, ReferenceType)]
 #[reference(instance_of = "Event")] // TODO: Better type check.

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -16,22 +16,24 @@ use na::{Point2, Point3, Vector2, Vector3};
 use crate::camera::{ArcBall, Camera};
 use crate::context::Context;
 use crate::event::{Action, EventManager, Key, WindowEvent};
-use image::imageops;
-use image::{GenericImage, Pixel};
-use image::{ImageBuffer, Rgb};
 use crate::light::Light;
-use ncollide3d::procedural::TriMesh;
 use crate::planar_camera::{FixedView, PlanarCamera};
 use crate::planar_line_renderer::PlanarLineRenderer;
 use crate::post_processing::PostProcessingEffect;
 #[cfg(feature = "conrod")]
 use crate::renderer::ConrodRenderer;
-use crate::renderer::{LineRenderer, PointRenderer, Renderer, PlanarRenderer};
-use crate::resource::{FramebufferManager, Mesh, PlanarMesh, RenderTarget, Texture, TextureManager};
+use crate::renderer::{LineRenderer, PlanarRenderer, PointRenderer, Renderer};
+use crate::resource::{
+    FramebufferManager, Mesh, PlanarMesh, RenderTarget, Texture, TextureManager,
+};
 use crate::scene::{PlanarSceneNode, SceneNode};
 use crate::text::{Font, TextRenderer};
 use crate::window::canvas::CanvasSetup;
 use crate::window::{Canvas, State};
+use image::imageops;
+use image::{GenericImage, Pixel};
+use image::{ImageBuffer, Rgb};
+use ncollide3d::procedural::TriMesh;
 
 #[cfg(feature = "conrod")]
 use std::collections::HashMap;

--- a/src/window/window.rs
+++ b/src/window/window.rs
@@ -26,7 +26,7 @@ use crate::planar_line_renderer::PlanarLineRenderer;
 use crate::post_processing::PostProcessingEffect;
 #[cfg(feature = "conrod")]
 use crate::renderer::ConrodRenderer;
-use crate::renderer::{LineRenderer, PointRenderer, Renderer};
+use crate::renderer::{LineRenderer, PointRenderer, Renderer, PlanarRenderer};
 use crate::resource::{FramebufferManager, Mesh, PlanarMesh, RenderTarget, Texture, TextureManager};
 use crate::scene::{PlanarSceneNode, SceneNode};
 use crate::text::{Font, TextRenderer};
@@ -1124,9 +1124,7 @@ impl Window {
         verify!(ctxt.active_texture(Context::TEXTURE0));
         // Clear the screen to black
 
-        if self.planar_line_renderer.needs_rendering() {
-            self.planar_line_renderer.render(camera);
-        }
+        self.planar_line_renderer.render(camera);
 
         // if self.point_renderer2.needs_rendering() {
         //     self.point_renderer2.render(camera);

--- a/src/window/windows_custom.rs
+++ b/src/window/windows_custom.rs
@@ -1,0 +1,829 @@
+//! The kiss3d window.
+/*
+ * FIXME: this file is too big. Some heavy refactoring need to be done here.
+ */
+use std::cell::RefCell;
+use std::iter::repeat;
+use std::path::Path;
+use std::rc::Rc;
+use std::sync::mpsc::{self, Receiver};
+use std::thread;
+use std::time::Duration;
+
+use instant::Instant;
+use na::{Point2, Point3, Vector2, Vector3};
+
+use crate::camera::Camera;
+use crate::context::Context;
+use crate::event::{Action, EventManager, Key, WindowEvent};
+use crate::light::Light;
+use crate::planar_camera::PlanarCamera;
+use crate::post_processing::PostProcessingEffect;
+#[cfg(feature = "conrod")]
+use crate::renderer::ConrodRenderer;
+use crate::renderer::{PlanarRenderer, Renderer};
+use crate::resource::{FramebufferManager, RenderTarget, Texture, TextureManager};
+use crate::text::{Font, TextRenderer};
+use crate::window::canvas::CanvasSetup;
+use crate::window::{Canvas, ExtendedState};
+use image::imageops;
+use image::{GenericImage, Pixel};
+use image::{ImageBuffer, Rgb};
+
+#[cfg(feature = "conrod")]
+use std::collections::HashMap;
+
+static DEFAULT_WIDTH: u32 = 800u32;
+static DEFAULT_HEIGHT: u32 = 600u32;
+
+#[cfg(feature = "conrod")]
+struct ConrodContext {
+    renderer: ConrodRenderer,
+    textures: conrod::image::Map<(Rc<Texture>, (u32, u32))>,
+    texture_ids: HashMap<String, conrod::image::Id>,
+}
+
+#[cfg(feature = "conrod")]
+impl ConrodContext {
+    fn new(width: f64, height: f64) -> Self {
+        Self {
+            renderer: ConrodRenderer::new(width, height),
+            textures: conrod::image::Map::new(),
+            texture_ids: HashMap::new(),
+        }
+    }
+}
+
+// Rendering mode used by the program, you can only switch
+// if two d data is provided.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum RenderMode {
+    ThreeD,
+    TwoD,
+}
+
+/// Structure representing a window and a 3D scene.
+///
+/// This is the main interface with the 3d engine.
+pub struct CustomWindow {
+    events: Rc<Receiver<WindowEvent>>,
+    unhandled_events: Rc<RefCell<Vec<WindowEvent>>>,
+    canvas: Canvas,
+    max_dur_per_frame: Option<Duration>,
+    light_mode: Light, // FIXME: move that to the scene graph
+    background: Vector3<f32>,
+    text_renderer: TextRenderer,
+    framebuffer_manager: FramebufferManager,
+    post_process_render_target: RenderTarget,
+    #[cfg(not(target_arch = "wasm32"))]
+    curr_time: Instant,
+    should_close: bool,
+    rendering_mode: RenderMode,
+    #[cfg(feature = "conrod")]
+    conrod_context: ConrodContext,
+}
+
+impl CustomWindow {
+    /// Indicates whether this window should be closed.
+    #[inline]
+    pub fn should_close(&self) -> bool {
+        self.should_close
+    }
+
+    /// The window width.
+    #[inline]
+    pub fn width(&self) -> u32 {
+        self.canvas.size().0
+    }
+
+    /// The window height.
+    #[inline]
+    pub fn height(&self) -> u32 {
+        self.canvas.size().1
+    }
+
+    /// The size of the window.
+    #[inline]
+    pub fn size(&self) -> Vector2<u32> {
+        let (w, h) = self.canvas.size();
+        Vector2::new(w, h)
+    }
+
+    /// Sets the maximum number of frames per second. Cannot be 0. `None` means there is no limit.
+    #[inline]
+    pub fn set_framerate_limit(&mut self, fps: Option<u64>) {
+        self.max_dur_per_frame = fps.map(|f| {
+            assert!(f != 0);
+            Duration::from_millis(1000 / f)
+        })
+    }
+
+    /// Switch the rendering mode
+    #[inline]
+    pub fn switch_rendering_mode(&mut self) {
+        self.rendering_mode = match self.rendering_mode {
+            RenderMode::ThreeD => RenderMode::TwoD,
+            RenderMode::TwoD => RenderMode::ThreeD,
+        }
+    }
+
+    /// Set window title
+    pub fn set_title(&mut self, title: &str) {
+        self.canvas.set_title(title)
+    }
+
+    /// Set the window icon. On wasm this does nothing.
+    ///
+    /// ```rust,should_panic
+    /// # extern crate kiss3d;
+    /// # extern crate image;
+    /// # use kiss3d::window::Window;
+    ///
+    /// # fn main() -> Result<(), image::ImageError> {
+    /// #    let mut window = Window::new("");
+    /// window.set_icon(image::open("foo.ico")?);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn set_icon(&mut self, icon: impl GenericImage<Pixel = impl Pixel<Subpixel = u8>>) {
+        self.canvas.set_icon(icon)
+    }
+
+    /// Set the cursor grabbing behaviour.
+    ///
+    /// If cursor grabbing is on, the cursor is prevented from leaving the window.
+    /// Does nothing on web platforms.
+    pub fn set_cursor_grab(&self, grab: bool) {
+        self.canvas.set_cursor_grab(grab);
+    }
+
+    /// Closes the window.
+    #[inline]
+    pub fn close(&mut self) {
+        self.should_close = true;
+    }
+
+    /// Hides the window, without closing it. Use `show` to make it visible again.
+    #[inline]
+    pub fn hide(&mut self) {
+        self.canvas.hide()
+    }
+
+    /// Makes the window visible. Use `hide` to hide it.
+    #[inline]
+    pub fn show(&mut self) {
+        self.canvas.show()
+    }
+
+    /// Sets the background color.
+    #[inline]
+    pub fn set_background_color(&mut self, r: f32, g: f32, b: f32) {
+        self.background.x = r;
+        self.background.y = g;
+        self.background.z = b;
+    }
+
+    /// Adds a string to be drawn during the next frame.
+    #[inline]
+    pub fn draw_text(
+        &mut self,
+        text: &str,
+        pos: &Point2<f32>,
+        scale: f32,
+        font: &Rc<Font>,
+        color: &Point3<f32>,
+    ) {
+        self.text_renderer.draw_text(text, pos, scale, font, color);
+    }
+
+    /// Load a texture from a file and return a reference to it.
+    pub fn add_texture(&mut self, path: &Path, name: &str) -> Rc<Texture> {
+        TextureManager::get_global_manager(|tm| tm.add(path, name))
+    }
+
+    /// Returns whether this window is closed or not.
+    pub fn is_closed(&self) -> bool {
+        false // FIXME
+    }
+
+    /// The hidpi factor of this screen.
+    pub fn hidpi_factor(&self) -> f64 {
+        self.canvas.hidpi_factor()
+    }
+
+    /// Sets the light mode. Only one light is supported.
+    pub fn set_light(&mut self, pos: Light) {
+        self.light_mode = pos;
+    }
+
+    /// Retrieve a mutable reference to the UI based on Conrod.
+    #[cfg(feature = "conrod")]
+    pub fn conrod_ui_mut(&mut self) -> &mut conrod::Ui {
+        self.conrod_context.renderer.ui_mut()
+    }
+
+    /// Attributes a conrod ID to the given texture and returns it if it exists.
+    #[cfg(feature = "conrod")]
+    pub fn conrod_texture_id(&mut self, name: &str) -> Option<conrod::image::Id> {
+        let tex = TextureManager::get_global_manager(|tm| tm.get_with_size(name))?;
+        let textures = &mut self.conrod_context.textures;
+        Some(
+            *self
+                .conrod_context
+                .texture_ids
+                .entry(name.to_string())
+                .or_insert_with(|| textures.insert(tex)),
+        )
+    }
+
+    /// Retrieve a reference to the UI based on Conrod.
+    #[cfg(feature = "conrod")]
+    pub fn conrod_ui(&self) -> &conrod::Ui {
+        self.conrod_context.renderer.ui()
+    }
+
+    /// Returns `true` if the mouse is currently interacting with a Conrod widget.
+    #[cfg(feature = "conrod")]
+    pub fn is_conrod_ui_capturing_mouse(&self) -> bool {
+        let ui = self.conrod_ui();
+        let state = &ui.global_input().current;
+        let window_id = Some(ui.window);
+
+        state.widget_capturing_mouse.is_some() && state.widget_capturing_mouse != window_id
+    }
+
+    /// Returns `true` if the keyboard is currently interacting with a Conrod widget.
+    #[cfg(feature = "conrod")]
+    pub fn is_conrod_ui_capturing_keyboard(&self) -> bool {
+        let ui = self.conrod_ui();
+        let state = &ui.global_input().current;
+        let window_id = Some(ui.window);
+
+        state.widget_capturing_keyboard.is_some() && state.widget_capturing_keyboard != window_id
+    }
+
+    /// Opens a window, hide it then calls a user-defined procedure.
+    ///
+    /// # Arguments
+    /// * `title` - the window title
+    pub fn new_hidden(title: &str) -> CustomWindow {
+        CustomWindow::do_new(title, true, DEFAULT_WIDTH, DEFAULT_HEIGHT, None)
+    }
+
+    /// Opens a window then calls a user-defined procedure.
+    ///
+    /// # Arguments
+    /// * `title` - the window title
+    pub fn new(title: &str) -> CustomWindow {
+        CustomWindow::do_new(title, false, DEFAULT_WIDTH, DEFAULT_HEIGHT, None)
+    }
+
+    /// Opens a window with a custom size then calls a user-defined procedure.
+    ///
+    /// # Arguments
+    /// * `title` - the window title.
+    /// * `width` - the window width.
+    /// * `height` - the window height.
+    pub fn new_with_size(title: &str, width: u32, height: u32) -> CustomWindow {
+        CustomWindow::do_new(title, false, width, height, None)
+    }
+
+    // FIXME: make this pub?
+    fn do_new(
+        title: &str,
+        hide: bool,
+        width: u32,
+        height: u32,
+        setup: Option<CanvasSetup>,
+    ) -> CustomWindow {
+        let (event_send, event_receive) = mpsc::channel();
+        let canvas = Canvas::open(title, hide, width, height, setup, event_send);
+
+        init_gl();
+
+        let mut usr_window = CustomWindow {
+            should_close: false,
+            max_dur_per_frame: None,
+            canvas: canvas,
+            events: Rc::new(event_receive),
+            unhandled_events: Rc::new(RefCell::new(Vec::new())),
+            light_mode: Light::Absolute(Point3::new(0.0, 10.0, 0.0)),
+            background: Vector3::new(0.0, 0.0, 0.0),
+            text_renderer: TextRenderer::new(),
+            #[cfg(feature = "conrod")]
+            conrod_context: ConrodContext::new(width as f64, height as f64),
+            post_process_render_target: FramebufferManager::new_render_target(
+                width as usize,
+                height as usize,
+                true,
+            ),
+            framebuffer_manager: FramebufferManager::new(),
+            #[cfg(not(target_arch = "wasm32"))]
+            curr_time: Instant::now(),
+            rendering_mode: RenderMode::ThreeD,
+        };
+
+        if hide {
+            usr_window.canvas.hide()
+        }
+
+        // usr_window.framebuffer_size_callback(DEFAULT_WIDTH, DEFAULT_HEIGHT);
+        let light = usr_window.light_mode.clone();
+        usr_window.set_light(light);
+
+        usr_window
+    }
+
+    // FIXME: give more options for the snap size and offset.
+    /// Read the pixels currently displayed to the screen.
+    ///
+    /// # Arguments:
+    /// * `out` - the output buffer. It is automatically resized.
+    pub fn snap(&self, out: &mut Vec<u8>) {
+        let (width, height) = self.canvas.size();
+        self.snap_rect(out, 0, 0, width as usize, height as usize)
+    }
+
+    /// Read a section of pixels from the screen
+    ///
+    /// # Arguments:
+    /// * `out` - the output buffer. It is automatically resized
+    /// * `x, y, width, height` - the rectangle to capture
+    pub fn snap_rect(&self, out: &mut Vec<u8>, x: usize, y: usize, width: usize, height: usize) {
+        let size = (width * height * 3) as usize;
+
+        if out.len() < size {
+            let diff = size - out.len();
+            out.extend(repeat(0).take(diff));
+        } else {
+            out.truncate(size)
+        }
+
+        // FIXME: this is _not_ the fastest way of doing this.
+        let ctxt = Context::get();
+        ctxt.pixel_storei(Context::PACK_ALIGNMENT, 1);
+        ctxt.read_pixels(
+            x as i32,
+            y as i32,
+            width as i32,
+            height as i32,
+            Context::RGB,
+            Some(out),
+        );
+    }
+
+    /// Get the current screen as an image
+    pub fn snap_image(&self) -> ImageBuffer<Rgb<u8>, Vec<u8>> {
+        let (width, height) = self.canvas.size();
+        let mut buf = Vec::new();
+        self.snap(&mut buf);
+        let img_opt = ImageBuffer::from_vec(width as u32, height as u32, buf);
+        let img = img_opt.expect("Buffer created from window was not big enough for image.");
+        imageops::flip_vertical(&img)
+    }
+
+    /// Gets the events manager that gives access to an event iterator.
+    pub fn events(&self) -> EventManager {
+        EventManager::new(self.events.clone(), self.unhandled_events.clone())
+    }
+
+    /// Gets the status of a key.
+    pub fn get_key(&self, key: Key) -> Action {
+        self.canvas.get_key(key)
+    }
+
+    /// Gets the last known position of the mouse.
+    ///
+    /// The position of the mouse is automatically updated when the mouse moves over the canvas.
+    pub fn cursor_pos(&self) -> Option<(f64, f64)> {
+        self.canvas.cursor_pos()
+    }
+
+    #[inline]
+    fn handle_events(
+        &mut self,
+        camera: &mut Option<&mut dyn Camera>,
+        planar_camera: &mut Option<&mut dyn PlanarCamera>,
+    ) {
+        let unhandled_events = self.unhandled_events.clone(); // FIXME: could we avoid the clone?
+        let events = self.events.clone(); // FIXME: could we avoid the clone?
+
+        for event in unhandled_events.borrow().iter() {
+            self.handle_event(camera, planar_camera, event)
+        }
+
+        for event in events.try_iter() {
+            self.handle_event(camera, planar_camera, &event)
+        }
+
+        unhandled_events.borrow_mut().clear();
+        self.canvas.poll_events();
+    }
+
+    fn handle_event(
+        &mut self,
+        camera: &mut Option<&mut dyn Camera>,
+        planar_camera: &mut Option<&mut dyn PlanarCamera>,
+        event: &WindowEvent,
+    ) {
+        match *event {
+            WindowEvent::Key(Key::Escape, Action::Release, _) | WindowEvent::Close => {
+                self.close();
+            }
+            WindowEvent::FramebufferSize(w, h) => {
+                self.update_viewport(w as f32, h as f32);
+            }
+            _ => {}
+        }
+
+        #[cfg(feature = "conrod")]
+        fn window_event_to_conrod_input(
+            event: WindowEvent,
+            size: Vector2<u32>,
+            hidpi: f64,
+        ) -> Option<conrod::event::Input> {
+            use conrod::event::Input;
+            use conrod::input::{Button, Key as CKey, Motion, MouseButton};
+
+            let transform_coords = |x: f64, y: f64| {
+                (
+                    (x - size.x as f64 / 2.0) / hidpi,
+                    -(y - size.y as f64 / 2.0) / hidpi,
+                )
+            };
+
+            match event {
+                WindowEvent::FramebufferSize(w, h) => {
+                    Some(Input::Resize(w as f64 / hidpi, h as f64 / hidpi))
+                }
+                WindowEvent::Focus(focus) => Some(Input::Focus(focus)),
+                WindowEvent::CursorPos(x, y, _) => {
+                    let (x, y) = transform_coords(x, y);
+                    Some(Input::Motion(Motion::MouseCursor { x, y }))
+                }
+                WindowEvent::Scroll(x, y, _) => Some(Input::Motion(Motion::Scroll { x, y: -y })),
+                WindowEvent::MouseButton(button, action, _) => {
+                    let button = match button {
+                        crate::event::MouseButton::Button1 => MouseButton::Left,
+                        crate::event::MouseButton::Button2 => MouseButton::Right,
+                        crate::event::MouseButton::Button3 => MouseButton::Middle,
+                        crate::event::MouseButton::Button4 => MouseButton::X1,
+                        crate::event::MouseButton::Button5 => MouseButton::X2,
+                        crate::event::MouseButton::Button6 => MouseButton::Button6,
+                        crate::event::MouseButton::Button7 => MouseButton::Button7,
+                        crate::event::MouseButton::Button8 => MouseButton::Button8,
+                    };
+
+                    match action {
+                        Action::Press => Some(Input::Press(Button::Mouse(button))),
+                        Action::Release => Some(Input::Release(Button::Mouse(button))),
+                    }
+                }
+                WindowEvent::Key(key, action, _) => {
+                    let key = match key {
+                        Key::Key1 => CKey::D1,
+                        Key::Key2 => CKey::D2,
+                        Key::Key3 => CKey::D3,
+                        Key::Key4 => CKey::D4,
+                        Key::Key5 => CKey::D5,
+                        Key::Key6 => CKey::D6,
+                        Key::Key7 => CKey::D7,
+                        Key::Key8 => CKey::D8,
+                        Key::Key9 => CKey::D9,
+                        Key::Key0 => CKey::D0,
+                        Key::A => CKey::A,
+                        Key::B => CKey::B,
+                        Key::C => CKey::C,
+                        Key::D => CKey::D,
+                        Key::E => CKey::E,
+                        Key::F => CKey::F,
+                        Key::G => CKey::G,
+                        Key::H => CKey::H,
+                        Key::I => CKey::I,
+                        Key::J => CKey::J,
+                        Key::K => CKey::K,
+                        Key::L => CKey::L,
+                        Key::M => CKey::M,
+                        Key::N => CKey::N,
+                        Key::O => CKey::O,
+                        Key::P => CKey::P,
+                        Key::Q => CKey::Q,
+                        Key::R => CKey::R,
+                        Key::S => CKey::S,
+                        Key::T => CKey::T,
+                        Key::U => CKey::U,
+                        Key::V => CKey::V,
+                        Key::W => CKey::W,
+                        Key::X => CKey::X,
+                        Key::Y => CKey::Y,
+                        Key::Z => CKey::Z,
+                        Key::Escape => CKey::Escape,
+                        Key::F1 => CKey::F1,
+                        Key::F2 => CKey::F2,
+                        Key::F3 => CKey::F3,
+                        Key::F4 => CKey::F4,
+                        Key::F5 => CKey::F5,
+                        Key::F6 => CKey::F6,
+                        Key::F7 => CKey::F7,
+                        Key::F8 => CKey::F8,
+                        Key::F9 => CKey::F9,
+                        Key::F10 => CKey::F10,
+                        Key::F11 => CKey::F11,
+                        Key::F12 => CKey::F12,
+                        Key::F13 => CKey::F13,
+                        Key::F14 => CKey::F14,
+                        Key::F15 => CKey::F15,
+                        Key::F16 => CKey::F16,
+                        Key::F17 => CKey::F17,
+                        Key::F18 => CKey::F18,
+                        Key::F19 => CKey::F19,
+                        Key::F20 => CKey::F20,
+                        Key::F21 => CKey::F21,
+                        Key::F22 => CKey::F22,
+                        Key::F23 => CKey::F23,
+                        Key::F24 => CKey::F24,
+                        Key::Pause => CKey::Pause,
+                        Key::Insert => CKey::Insert,
+                        Key::Home => CKey::Home,
+                        Key::Delete => CKey::Delete,
+                        Key::End => CKey::End,
+                        Key::PageDown => CKey::PageDown,
+                        Key::PageUp => CKey::PageUp,
+                        Key::Left => CKey::Left,
+                        Key::Up => CKey::Up,
+                        Key::Right => CKey::Right,
+                        Key::Down => CKey::Down,
+                        Key::Return => CKey::Return,
+                        Key::Space => CKey::Space,
+                        Key::Caret => CKey::Caret,
+                        Key::Numpad0 => CKey::NumPad0,
+                        Key::Numpad1 => CKey::NumPad1,
+                        Key::Numpad2 => CKey::NumPad2,
+                        Key::Numpad3 => CKey::NumPad3,
+                        Key::Numpad4 => CKey::NumPad4,
+                        Key::Numpad5 => CKey::NumPad5,
+                        Key::Numpad6 => CKey::NumPad6,
+                        Key::Numpad7 => CKey::NumPad7,
+                        Key::Numpad8 => CKey::NumPad8,
+                        Key::Numpad9 => CKey::NumPad9,
+                        Key::Add => CKey::Plus,
+                        Key::At => CKey::At,
+                        Key::Backslash => CKey::Backslash,
+                        Key::Calculator => CKey::Calculator,
+                        Key::Colon => CKey::Colon,
+                        Key::Comma => CKey::Comma,
+                        Key::Equals => CKey::Equals,
+                        Key::LBracket => CKey::LeftBracket,
+                        Key::LControl => CKey::LCtrl,
+                        Key::LShift => CKey::LShift,
+                        Key::Mail => CKey::Mail,
+                        Key::MediaSelect => CKey::MediaSelect,
+                        Key::Minus => CKey::Minus,
+                        Key::Mute => CKey::Mute,
+                        Key::NumpadComma => CKey::NumPadComma,
+                        Key::NumpadEnter => CKey::NumPadEnter,
+                        Key::NumpadEquals => CKey::NumPadEquals,
+                        Key::Period => CKey::Period,
+                        Key::Power => CKey::Power,
+                        Key::RAlt => CKey::RAlt,
+                        Key::RBracket => CKey::RightBracket,
+                        Key::RControl => CKey::RCtrl,
+                        Key::RShift => CKey::RShift,
+                        Key::Semicolon => CKey::Semicolon,
+                        Key::Slash => CKey::Slash,
+                        Key::Sleep => CKey::Sleep,
+                        Key::Stop => CKey::Stop,
+                        Key::Tab => CKey::Tab,
+                        Key::VolumeDown => CKey::VolumeDown,
+                        Key::VolumeUp => CKey::VolumeUp,
+                        Key::Copy => CKey::Copy,
+                        Key::Paste => CKey::Paste,
+                        Key::Cut => CKey::Cut,
+                        _ => CKey::Unknown,
+                    };
+
+                    match action {
+                        Action::Press => Some(Input::Press(Button::Keyboard(key))),
+                        Action::Release => Some(Input::Release(Button::Keyboard(key))),
+                    }
+                }
+                _ => None,
+            }
+        }
+
+        #[cfg(feature = "conrod")]
+        {
+            let (size, hidpi) = (self.size(), self.hidpi_factor());
+            let conrod_ui = self.conrod_ui_mut();
+            if let Some(input) = window_event_to_conrod_input(*event, size, hidpi) {
+                conrod_ui.handle_event(input);
+            }
+
+            let state = &conrod_ui.global_input().current;
+            let window_id = Some(conrod_ui.window);
+
+            if event.is_keyboard_event()
+                && state.widget_capturing_keyboard.is_some()
+                && state.widget_capturing_keyboard != window_id
+            {
+                return;
+            }
+
+            if event.is_mouse_event()
+                && state.widget_capturing_mouse.is_some()
+                && state.widget_capturing_mouse != window_id
+            {
+                return;
+            }
+        }
+
+        // Only handle events for the current mode.
+        match self.rendering_mode {
+            RenderMode::ThreeD => match *camera {
+                Some(ref mut cam) => cam.handle_event(&self.canvas, event),
+                None => (),
+            },
+            RenderMode::TwoD => match *planar_camera {
+                Some(ref mut cam) => cam.handle_event(&self.canvas, event),
+                None => (),
+            },
+        }
+    }
+
+    /// Runs the render and event loop until the window is closed.
+    pub fn render_loop<S: ExtendedState>(mut self, mut state: S) {
+        Canvas::render_loop(move |_| self.do_render_with_state(&mut state))
+    }
+
+    /// Render one frame using the specified state.
+    #[cfg(not(any(target_arch = "wasm32", target_arch = "asmjs")))]
+    pub fn render_with_state<S: ExtendedState>(&mut self, state: &mut S) -> bool {
+        self.do_render_with_state(state)
+    }
+
+    fn do_render_with_state<S: ExtendedState>(&mut self, state: &mut S) -> bool {
+        {
+            let (camera, planar_camera, renderer, planar_renderer, effect) =
+                state.cameras_and_effect_and_renderers();
+            self.should_close =
+                !self.do_render_with(camera, planar_camera, renderer, planar_renderer, effect);
+        }
+
+        if !self.should_close {
+            state.step(self)
+        }
+
+        !self.should_close
+    }
+
+    fn do_render_with(
+        &mut self,
+        camera: Option<&mut dyn Camera>,
+        planar_camera: Option<&mut dyn PlanarCamera>,
+        renderer: Option<&mut dyn Renderer>,
+        planar_renderer: Option<&mut dyn PlanarRenderer>,
+        post_processing: Option<&mut dyn PostProcessingEffect>,
+    ) -> bool {
+        let mut camera = camera;
+        let mut planar_camera = planar_camera;
+        self.handle_events(&mut camera, &mut planar_camera);
+
+        match (camera, planar_camera) {
+            (Some(cam), Some(cam_planar)) => self.render_single_frame(
+                cam,
+                cam_planar,
+                renderer,
+                planar_renderer,
+                post_processing,
+            ),
+            // TODO: Fallback to basic camera instead of crashing
+            _ => panic!("No cameras available"),
+        }
+    }
+
+    fn render_single_frame(
+        &mut self,
+        camera: &mut dyn Camera,
+        planar_camera: &mut dyn PlanarCamera,
+        mut renderer: Option<&mut dyn Renderer>,
+        mut planar_renderer: Option<&mut dyn PlanarRenderer>,
+        mut post_processing: Option<&mut dyn PostProcessingEffect>,
+    ) -> bool {
+        let w = self.width();
+        let h = self.height();
+
+        planar_camera.handle_event(&self.canvas, &WindowEvent::FramebufferSize(w, h));
+        camera.handle_event(&self.canvas, &WindowEvent::FramebufferSize(w, h));
+        planar_camera.update(&self.canvas);
+        camera.update(&self.canvas);
+
+        match self.light_mode {
+            Light::StickToCamera => self.set_light(Light::StickToCamera),
+            _ => {}
+        }
+
+        if post_processing.is_some() {
+            // if we need post-processing, render to our own frame buffer
+            self.framebuffer_manager
+                .select(&self.post_process_render_target);
+        } else {
+            self.framebuffer_manager
+                .select(&FramebufferManager::screen());
+        }
+
+        self.clear_screen();
+
+        match self.rendering_mode {
+            RenderMode::ThreeD => {
+                // Draw the 3D scene
+                if let Some(ref mut renderer) = renderer {
+                    renderer.render(1usize, camera)
+                }
+            }
+            RenderMode::TwoD => {
+                // Draw the 2D scene
+                if let Some(ref mut renderer) = planar_renderer {
+                    renderer.render(planar_camera);
+                }
+            }
+        }
+
+        let (znear, zfar) = camera.clip_planes();
+
+        if let Some(ref mut p) = post_processing {
+            // switch back to the screen framebuffer …
+            self.framebuffer_manager
+                .select(&FramebufferManager::screen());
+            // … and execute the post-process
+            // FIXME: use the real time value instead of 0.016!
+            p.update(0.016, w as f32, h as f32, znear, zfar);
+            p.draw(&self.post_process_render_target);
+        }
+
+        // TODO: Seperate ui rendering based on viewing mode?
+        self.text_renderer.render(w as f32, h as f32);
+        #[cfg(feature = "conrod")]
+        self.conrod_context.renderer.render(
+            w as f32,
+            h as f32,
+            self.canvas.hidpi_factor() as f32,
+            &self.conrod_context.textures,
+        );
+
+        // We are done: swap buffers
+        self.canvas.swap_buffers();
+
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            // Limit the fps if needed.
+            if let Some(dur) = self.max_dur_per_frame {
+                let elapsed = self.curr_time.elapsed();
+                if elapsed < dur {
+                    thread::sleep(dur - elapsed);
+                }
+            }
+
+            self.curr_time = Instant::now();
+        }
+
+        // self.transparent_objects.clear();
+        // self.opaque_objects.clear();
+
+        !self.should_close()
+    }
+
+    fn clear_screen(&self) {
+        let ctxt = Context::get();
+        // Activate the default texture
+        verify!(ctxt.active_texture(Context::TEXTURE0));
+        // Clear the screen to black
+        verify!(ctxt.clear_color(self.background.x, self.background.y, self.background.z, 1.0));
+        verify!(ctxt.clear(Context::COLOR_BUFFER_BIT));
+        verify!(ctxt.clear(Context::DEPTH_BUFFER_BIT));
+    }
+
+    fn update_viewport(&mut self, w: f32, h: f32) {
+        // Update the viewport
+        verify!(Context::get().scissor(0, 0, w as i32, h as i32));
+        FramebufferManager::screen().resize(w, h);
+        self.post_process_render_target.resize(w, h);
+    }
+}
+
+fn init_gl() {
+    /*
+     * Misc configurations
+     */
+    let ctxt = Context::get();
+    verify!(ctxt.front_face(Context::CCW));
+    verify!(ctxt.enable(Context::DEPTH_TEST));
+    verify!(ctxt.enable(Context::SCISSOR_TEST));
+    #[cfg(not(any(target_arch = "wasm32", target_arch = "asmjs")))]
+    {
+        verify!(ctxt.enable(Context::PROGRAM_POINT_SIZE));
+    }
+    verify!(ctxt.depth_func(Context::LEQUAL));
+    verify!(ctxt.front_face(Context::CCW));
+    verify!(ctxt.enable(Context::CULL_FACE));
+    verify!(ctxt.cull_face(Context::BACK));
+}

--- a/src/window/windows_custom.rs
+++ b/src/window/windows_custom.rs
@@ -127,6 +127,12 @@ impl CustomWindow {
         }
     }
 
+    /// Retrieve the current rendering mode
+    #[inline]
+    pub fn get_rendering_mode(&self) -> RenderMode {
+        self.rendering_mode
+    }
+
     /// Set window title
     pub fn set_title(&mut self, title: &str) {
         self.canvas.set_title(title)

--- a/src/window/windows_custom.rs
+++ b/src/window/windows_custom.rs
@@ -788,7 +788,7 @@ impl CustomWindow {
         &mut self,
         planar_camera: &mut dyn PlanarCamera,
         mut planar_renderer: Option<&mut dyn PlanarRenderer>,
-        mut post_processing: Option<&mut dyn PostProcessingEffect>,
+        post_processing: Option<&mut dyn PostProcessingEffect>,
     ) -> bool {
         let w = self.width();
         let h = self.height();


### PR DESCRIPTION
These code changes allow for a better support of customer rendering implementations. It adds a _Custom Windows_ which can only be used with a user defined Renderer and Planar Renderer. It also allows the user to switch between these 2 views.

PR here is mostly so I can easily keep track of the changes myself.

TODO:
- [ ] Change the normal state instead of defining a new one and build in backwards compatibility.
- [x] Ensure the current planar renderers use the new `PlanarRender` trait and have the window use this.
- [x] Add a persistent point renderer with clear option.
- [ ] Clean up the custom Window implementation with comments